### PR TITLE
Remove unused tracking

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -18,7 +18,7 @@ service_link: /
 max_toc_heading_level: 2
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
-ga_tracking_id: UA-86101042-3
+# ga_tracking_id: UA-XXXX-Y
 
 google_site_verification: "IJ5HOXpZrISM6la-YO_iX0rBUC5YFftpexygcKLsNs4"
 


### PR DESCRIPTION
We are not using the data collected (data minimisation) from this tracking and our users are not aware of it happening since there is no cookie banner (consent).

- [GDPR Data Minimisation](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/principles/data-minimisation/)
- [GDPR Consent](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/lawful-basis-for-processing/consent/)
