### PR TITLE
Add accessibility statement, and link in footer

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -11,6 +11,8 @@ service_link: /
 #   About: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/communities-of-practice/content/technical-writing
 #   Documentation: /
 #   Support: /
+footer_links:
+  Accessibility: /accessibility.html
 
 # Table of contents depth – how many levels to include in the table of contents.
 # If your ToC is too long, reduce this number and we'll only show higher-level

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,0 +1,67 @@
+---
+title: Accessibility statement for GOV.UK Prototype Kit training documentation
+last_reviewed_on: 2020-09-01
+review_in: 6 months
+hide_in_navigation: true
+---
+
+# Accessibility statement for GOV.UK Prototype Kit training documentation
+
+This accessibility statement applies to the GOV.UK Prototype Kit training documentation at [https://prototype-kit-training.cloudapps.digital/](https://prototype-kit-training.cloudapps.digital/).
+
+This website is run by the GOV.UK Design System team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
++ change colours, contrast levels and fonts
++ zoom in up to 300% without problems
++ navigate most of the website using just a keyboard
++ navigate most of the website using speech recognition software
++ listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+
+We’ve also made the website text as simple as possible to understand.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
+
+## How accessible this website is
+
+We know some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
+
+## Feedback and contact information
+
+If you need any part of this service in a different format like large print, audio recording or braille, email [govuk-design-system-support@digital.cabinet-office.gov.uk](mailto:govuk-design-system-support@digital.cabinet-office.gov.uk).
+
+We’ll consider your request and get back to you within 3 working days.
+
+## Reporting accessibility problems with this website
+
+We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email [govuk-design-system-support@digital.cabinet-office.gov.uk](mailto:govuk-design-system-support@digital.cabinet-office.gov.uk).
+
+## Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
+(the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+
+## Technical information about this website’s accessibility
+
+GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+### Compliance status
+
+This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, due to the non-compliances listed below.
+
+#### Non-accessible content
+
+The content listed below is non-accessible for the following reasons.
+
+#### Non-compliance with the accessibility regulations
+
+Some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
+
+## What we’re doing to improve accessibility
+
+We plan to fix the issues with the Technical Documentation Template by the end of 2020.
+
+## Preparation of this accessibility statement
+
+This statement was prepared on 2 September 2020. It was last reviewed on 2 September 2020.
+
+This website was last tested in July 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested all the website's pages.


### PR DESCRIPTION
### Context
We're doing an overall accessibility audit of our Tech Docs Template technical documentation across GDS.

### Changes proposed in this pull request
Following the [audit and improvements](https://github.com/alphagov/prototype-kit-training/issues/34) to the Prototype Kit training site in July, we now need to publish an accessibility statement.

### Before we merge

- [x] Publish overall TDT statement
- [x] Add missing date 