### PR TITLE
Deploy using CloudFoundry CLI v7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_deploy:
   - wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
   - echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
   - sudo apt-get update
-  - sudo apt-get install -y cf-cli
+  - sudo apt-get install -y cf7-cli
 
 # We use a script rather than using Travis' built in CloudFoundry provider
 # because it does not support zero downtime deploys

--- a/bin/deploy-travis
+++ b/bin/deploy-travis
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
-set -x
 
-cf api $CF_API
-cf auth # uses CF_USERNAME / CF_PASSWORD from environment
-cf target -o $CF_ORG -s $CF_SPACE
+# Exit if the deploy script hits an error or unset variable
+set -eu
 
 # Parse app name from manifest to ensure it matches up
 APP_NAME=$(ruby -e "require 'yaml'; config = YAML.load_file('manifest.yml'); puts config['applications'][0]['name']")
 
-cf v3-create-app $APP_NAME
-cf v3-apply-manifest -f manifest.yml
-# Deploy using CloudFoundry zero-downtime push
-cf v3-zdt-push $APP_NAME -p build --wait-for-deploy-complete
+cf api "$CF_API"
+cf auth # uses CF_USERNAME / CF_PASSWORD from environment
+cf target -o "$CF_ORG" -s "$CF_SPACE"
+cf push $APP_NAME --strategy rolling


### PR DESCRIPTION
Install version 7 of the CloudFoundry CLI and use it to deploy the site to PaaS.

The cf push command in v7 has a new flag —strategy which ‘can deploy an app without causing downtime using [—strategy rolling’][1] – which is equivalent to the `v3-zdt-push` command. We also no longer need to manually create the app or apply the manifest, which means we no longer need to extract the app path from the manifest.

These changes mirror the [changes made in alphagov/learn-to-code][2] which had the same problem, and the same approach [now used for govuk-frontend-docs][3].

[1]: https://docs.cloudfoundry.org/cf-cli/v7.html#:~:text=You%20can%20deploy%20an%20app%20without%20causing%20downtime%20using%20cf%20push%20app_name%20--strategy%20rolling
[2]: https://github.com/alphagov/learn-to-code/pull/40
[3]: https://github.com/alphagov/govuk-frontend-docs/pull/93

Closes #44 