### PR TITLE
Update PK accessibility statement after TDT fixes

### DIFF
--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Accessibility statement for GOV.UK Prototype Kit training documentation
-last_reviewed_on: 2020-09-01
+last_reviewed_on: 2021-03-29
 review_in: 6 months
 hide_in_navigation: true
 ---
@@ -23,7 +23,7 @@ We’ve also made the website text as simple as possible to understand.
 
 ## How accessible this website is
 
-We know some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
+This website is fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
 
 ## Feedback and contact information
 
@@ -46,22 +46,14 @@ GDS is committed to making its website accessible, in accordance with the Public
 
 ### Compliance status
 
-This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, due to the non-compliances listed below.
-
-#### Non-accessible content
-
-The content listed below is non-accessible for the following reasons.
-
-#### Non-compliance with the accessibility regulations
-
-Some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
+This website is fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
 
 ## What we’re doing to improve accessibility
 
-We plan to fix the issues with the Technical Documentation Template by the end of March 2021.
+When we publish new content, we'll continue to make sure that it meets accessibility standards.
 
 ## Preparation of this accessibility statement
 
-This statement was prepared on 2 September 2020. It was last reviewed on 21 December 2020.
+This statement was prepared on 2 September 2020. It was last reviewed on 29 March 2021.
 
-This website was last tested in July 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested all the website's pages.
+We last tested this website for accessibility issues in March 2021.


### PR DESCRIPTION
Fixes [#53](https://github.com/alphagov/prototype-kit-training/issues/53) (Remove references to accessibility issues in Frontend Docs from accessibility statement [before 31 March]).

The [most recent update to the Tech Docs Template](https://github.com/alphagov/govuk-frontend-docs/pull/109) has fixed some accessibility issues. For example, users of assistive tech will now no longer be able to focus elements that should remain hidden on pages. So, we now need to update our accessibility statement to say that our Kit-training-docs site is fully compliant with the WCAG 2.1 AA standard.

This PR also contains:
- an updated review date for the accessibility statement
- deletions of outdated information (about WCAG only being partly met because of issues with the Template)