### PR TITLE
Replace references to `master` with `main`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ deploy:
   # deployed!
   skip_cleanup: true
   on:
-    branch: master
+    branch: main

--- a/source/task-5.html.md.erb
+++ b/source/task-5.html.md.erb
@@ -50,6 +50,12 @@ When you're done, select **Create repository**.
     git init
     ```
 
+3. The default branch created by the `git init` command is called `master`, which is a [potentially offensive term](https://sfconservancy.org/news/2020/jun/23/gitbranchname/). Rename the current branch to `main` instead:
+
+    ```shell
+    git branch -M main
+    ```
+
 ### Add and commit your prototype files
 
 1. Add all the files in the local repo and stage them for commit:
@@ -63,7 +69,7 @@ When you're done, select **Create repository**.
     ```shell
     git status
     ```
-    
+
 2. Commit the staged files:
 
     ```shell
@@ -88,11 +94,11 @@ When you're done, select **Create repository**.
     ```
 
     `REMOTE-REPO-URL` is the url you copied.
-    
+
 5. Push the changes in your local repo to the remote repo:
 
     ```shell
-    git push -u origin master
+    git push -u origin main
     ```
 
 You have now created a remote version of your prototype on GitHub. Go to the remote repo and check that all your files are there.
@@ -149,7 +155,7 @@ Password: your_token
 4. Select **Europe** as the region - this is not important but makes your prototype a bit faster.
 
 5. Select **Create app**.
- 
+
 6. Set **Deployment method** as **GitHub**, then select **Connect to GitHub**.
 
 7. In the popup, select **Authorize Heroku**.

--- a/source/using-the-terminal-and-git.html.md.erb
+++ b/source/using-the-terminal-and-git.html.md.erb
@@ -109,7 +109,7 @@ You should see an error message like:
 
 ### Create a repository
 
-A Git repository is a virtual storage of your project. It allows you to save versions of your code, which you can access when needed. 
+A Git repository is a virtual storage of your project. It allows you to save versions of your code, which you can access when needed.
 
 Create a new local repository with the specified name:
 
@@ -157,10 +157,10 @@ Upload all local branch commits to GitHub:
 git push REMOTE-BRANCH-NAME BRANCH-NAME
 ```
 
-If pushing to a master branch from a local repo (a folder on your device), you can write the above as:
+If pushing to a `main` branch from a local repo (a folder on your device), you can write the above as:
 
 ```shell
-git push origin master
+git push origin main
 ```
 
 Download history from a remote directory and incorporate the changes in your local version:


### PR DESCRIPTION
Part of https://github.com/alphagov/design-system-team-internal/issues/423

## What
Replace references to `master` with `main`.

## Why

- One task steps a user through creating a new Github repo. All new Github repos have a `main` branch instead of a `master` branch, so we need to update that command
- An introduction to using the terminal gives an example of pushing to a `master` branch. Update this example to use a `main` branch. The branch name shouldn't matter as it's just an example.
- Update the Travis config to replace `master` with `main`. The Travis config will also be manually updated in the UI to specify `main` as the new default branch before this PR is merged.
