### PR TITLE
Update link to Prototype Kit docs

### DIFF
--- a/source/task-2.html.md.erb
+++ b/source/task-2.html.md.erb
@@ -7,7 +7,7 @@ weight: 20
 
 ## Main task 
 
-Follow the tutorial on how to [add questions to your question pages](https://govuk-prototype-kit.herokuapp.com/docs/make-first-prototype/add-questions).
+Follow the tutorial on how to [use components from the Design System to add questions to your question pages](https://govuk-prototype-kit.herokuapp.com/docs/make-first-prototype/use-components).
 
 ## Stretch task
 


### PR DESCRIPTION
Avoid an unnecessary redirect and update the link text so that users better understand how the guidance they end up on relates to the task they're doing.